### PR TITLE
Makes listener and subscriber paths relative.

### DIFF
--- a/pyrostest/mock_nodes.py
+++ b/pyrostest/mock_nodes.py
@@ -5,6 +5,7 @@ Contains tools to send and recieve data from fake nodes and topics.
 
 import contextlib
 import cPickle as pickle
+import os
 import subprocess
 import time
 import threading
@@ -31,8 +32,8 @@ class MockPublisher(object):
         self.topic = topic
         self.msg_type = msg_type
         pub_data = pickle.dumps((topic, msg_type, queue_size))
-        # this might be fragile if not run from the ci_scripts/unittest command
-        location = './tests/test_utils/publisher.py'
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        location = os.path.join(this_dir, 'publisher.py')
         self.proc = subprocess.Popen([location, pub_data],
                 stdin=subprocess.PIPE)
 
@@ -74,8 +75,8 @@ class MockListener(object):
         self.msg_type = msg_type
         self.killed = False
 
-        # this might be fragile if not run from the ci_scripts/unittest command
-        location = './tests/test_utils/listener.py'
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        location = os.path.join(this_dir, 'listener.py')
         self.proc = subprocess.Popen([location,
             pickle.dumps((topic, msg_type))], stdout=subprocess.PIPE)
         self._message = None

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ test = []
 
 setup(
     name='pyrostest',
-    version='0.0.2',
+    version='0.0.3',
     description='The most lit ros testing framework',
     packages=['pyrostest'],
     install_requires=required,


### PR DESCRIPTION
This closes #4. More generally, now you can run `pytest
path/to/dir/with/tests` from anywhere and it should work, because the
path is calculated based on the relative distance from the source files
in the package, instead of relative to where the command is run.