### PR TITLE
Add python 3 compatibility

### DIFF
--- a/pyrostest/ros_test.py
+++ b/pyrostest/ros_test.py
@@ -12,6 +12,7 @@ import pkg_resources
 import subprocess
 import time
 import threading
+import six
 from six import StringIO
 from six.moves import cPickle as pickle
 import unittest
@@ -157,14 +158,14 @@ def _await_node(topic, prefix, rosmaster_uri, timeout):
 
 
 
-
+@six.add_metaclass(pyrostest.rostest_utils.RosTestMeta)
 class RosTest(unittest.TestCase):
     """A subclass of TestCase that exposes some additional ros-related attrs.
 
     self.port is the port this instance will run on.
-    self.rosmaster_uri is equivalent to the ROS_MASTER_URI environmental var
+    self.rosmaster_uri is equivalent to the ROS_MASTER_URI environmental var,
+        and is set by the metaclass.
     """
-    __metaclass__ = pyrostest.rostest_utils.RosTestMeta
 
     def __init__(self, *args, **kwargs):
         super(RosTest, self).__init__(*args, **kwargs)

--- a/pyrostest/ros_test.py
+++ b/pyrostest/ros_test.py
@@ -7,13 +7,13 @@ it over the system.
 """
 
 import contextlib
-import cPickle as pickle
 import os
 import pkg_resources
 import subprocess
 import time
 import threading
-from StringIO import StringIO
+from six import StringIO
+from six.moves import cPickle as pickle
 import unittest
 
 import pyrostest.rostest_utils

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with codecs.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 required = [
     'psutil==5.1.3',
-    'six=1.11.0',
+    'six==1.11.0',
     ]
 
 test = [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ test = [
 
 setup(
     name='pyrostest',
-    version='0.1.12',
+    version='0.1.13',
     description='The most lit ros testing framework',
     long_description=long_description,
     packages=['pyrostest'],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ with codecs.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = '\n' + f.read()
 
 required = [
-    'psutil==5.1.3'
+    'psutil==5.1.3',
+    'six=1.11.0',
     ]
 
 test = [
@@ -39,6 +40,7 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
         ],
     )
 


### PR DESCRIPTION
I'm working on making `./ci_scripts/simulation` work in buzzmo locally, and am starting by making this work on python2 and 3 for compatibility reasons.